### PR TITLE
Making requests to different dex-ags simultaniosly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 run: contracts/Trader.json
 	deno run \
 		--allow-env=INFURA_PROJECT_ID \
-		--allow-net=api.cow.fi,mainnet.infura.io,api.1inch.io,api.0x.org,apiv5.paraswap.io \
+		--allow-net=api.cow.fi,mainnet.infura.io,api.1inch.io,api.0x.org,apiv5.paraswap.io,ethapi.openocean.finance \
 		--allow-read=orders.db,orders.db-journal \
 		--allow-write=orders.db,orders.db-journal \
 		src/index.js

--- a/README.md
+++ b/README.md
@@ -1,14 +1,30 @@
-# DEXag Trader
+, DEXag Trader
 
-This repo contains a daemon that monitors the CoW Protocol orderbook and, for each new order, simulates trading the order amounts on various DEX aggregators.
-The simulation records both the expected traded amounts as well as the actual executed amounts.
+This repo contains a daemon that monitors the CoW Protocol orderbook and, for
+each new order, simulates trading the order amounts on various DEX aggregators.
+The simulation records both the expected traded amounts as well as the actual
+executed amounts.
 
 ## Simulation Details
 
-Simulation is done with an `eth_call` with state overrides.
-This allows simulations to work even for traders that haven't approved the required contracts.
+Simulation is done with an `eth_call` with state overrides. This allows
+simulations to work even for traders that haven't approved the required
+contracts.
 
 ## Output
 
-The daemon writes to an SQLite database `orders.db`.
-It includes details of the original CoW Protocol order and trade simulation results for each DEX aggregator.
+The daemon writes to an SQLite database `orders.db`. It includes details of the
+original CoW Protocol order and trade simulation results for each DEX
+aggregator.
+
+## How to run it:
+
+1. install deno
+
+2. run:
+
+```
+export INFURA_PROJECT_ID=<key>
+make run
+```
+

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,202 @@
+import { ethers } from "https://cdn.ethers.io/lib/ethers-5.6.esm.min.js";
+import { Exchange } from "./exchange.js";
+import { Tokens } from "./tokens.js";
+import { handleJson } from "./utils.js";
+import { DB } from "https://deno.land/x/sqlite@v3.4.1/mod.ts";
+
+export function generateExchangeConfig(db, provider) {
+  return [
+    new Exchange("ocean", db, provider, async (order, gasPrice, ethPrice) => {
+      if (order.kind !== "sell") {
+        return null;
+      }
+      // based on the following call from defi lama
+      // https://ethapi.openocean.finance/v2/1/swap?inTokenAddress=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&outTokenAddress=0x6b175474e89094c44da98b954eedeac495271d0f&amount=10000000000000000000&gasPrice=244549634&slippage=50&account=0x06cd12cECE75D65dD33068dcd26627A42aF6dF3E&referrer=0x5521c3dfd563d48ca64e132324024470f3498526
+      const params = [
+        `inTokenAddress=${order.sellToken}`,
+        `outTokenAddress=${order.buyToken}`,
+        `amount=${order.sellAmount}`,
+        `gasPrice=${gasPrice}`,
+        `slippage=50`,
+        `account=${order.owner}`,
+      ].join("&");
+      const swap = await fetch(
+        `https://ethapi.openocean.finance/v2/1/swap?${params}`,
+      ).then(handleJson);
+
+      return {
+        spender: ethers.utils.getAddress(
+          "0x6352a56caadc4f1e25cd6c75970fa768a3304e64",
+        ),
+        exchange: ethers.utils.getAddress(swap.to),
+        data: swap.data,
+        feeUsd: (swap.estimatedGas * gasPrice) / ethPrice,
+        sellAmount: ethers.BigNumber.from(swap.inAmount),
+        buyAmount: ethers.BigNumber.from(swap.outAmount),
+      };
+    }),
+    new Exchange("oneinch", db, provider, async (order, gasPrice, ethPrice) => {
+      if (order.kind !== "sell") {
+        return null;
+      }
+      // based on the following requests from defi lama
+      // https://api.1inch.io/v4.0/1/swap?fromTokenAddress=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&toTokenAddress=0x6b175474e89094c44da98b954eedeac495271d0f&amount=10000000000000000000&fromAddress=0x06cd12cECE75D65dD33068dcd26627A42aF6dF3E&slippage=0.5&referrerAddress=0x08a3c2A819E3de7ACa384c798269B3Ce1CD0e437&disableEstimate=true
+      // https://api.1inch.io/v4.0/1/quote?fromTokenAddress=0xdac17f958d2ee523a2206206994597c13d831ec7&toTokenAddress=0x6b175474e89094c44da98b954eedeac495271d0f&amount=10000000&slippage=0.5
+      const params = [
+        `fromTokenAddress=${order.sellToken}`,
+        `toTokenAddress=${order.buyToken}`,
+        `amount=${order.sellAmount}`,
+        `fromAddress=${order.owner}`,
+        `gasPrice=${gasPrice}`,
+        `slippage=1`,
+        `disableEstimate=true`,
+      ].join("&");
+      const params2 = [
+        `fromTokenAddress=${order.sellToken}`,
+        `toTokenAddress=${order.buyToken}`,
+        `amount=${order.sellAmount}`,
+        `gasPrice=${gasPrice}`,
+        `fromAddress=${order.owner}`,
+        `slippage=0.5`,
+      ].join("&");
+      const [spender, swap, quote] = await Promise.all([
+        fetch("https://api.1inch.io/v4.0/1/approve/spender").then(handleJson),
+        fetch(`https://api.1inch.io/v4.0/1/swap?${params}`).then(handleJson),
+        fetch(`https://api.1inch.io/v4.0/1/quote?${params2}`).then(handleJson),
+      ]);
+      return {
+        spender: ethers.utils.getAddress(spender.address),
+        exchange: ethers.utils.getAddress(swap.tx.to),
+        data: swap.tx.data,
+        feeUsd: (quote.estimatedGas * gasPrice) / ethPrice,
+        sellAmount: ethers.BigNumber.from(swap.fromTokenAmount),
+        buyAmount: ethers.BigNumber.from(swap.toTokenAmount),
+      };
+    }),
+
+    new Exchange("zeroex", db, provider, async (order, gasPrice, ethPrice) => {
+      // based on the following calls from defi lama and adding the gas price
+      // https://api.0x.org/swap/v1/quote?buyToken=0x6b175474e89094c44da98b954eedeac495271d0f&sellToken=0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2&sellAmount=10000000000000000000&slippagePercentage=0.005&affiliateAddress=0x08a3c2A819E3de7ACa384c798269B3Ce1CD0e437&enableSlippageProtection=false
+      const params = [
+        `sellToken=${order.sellToken}`,
+        `buyToken=${order.buyToken}`,
+        order.kind === "sell"
+          ? `sellAmount=${order.sellAmount}`
+          : `buyAmount=${order.buyAmount}`,
+        `slippagePercentage=0.005`,
+        `takerAddress=${order.owner}`,
+        `gasPrice=${gasPrice}`,
+        `skipValidation=true`,
+        `enableSlippageProtection=false`,
+      ].join("&");
+      const quote = await fetch(
+        `https://api.0x.org/swap/v1/quote?${params}`,
+      ).then(handleJson);
+
+      return {
+        spender: ethers.utils.getAddress(quote.allowanceTarget),
+        exchange: ethers.utils.getAddress(quote.to),
+        data: quote.data,
+        feeUsd: (quote.estimatedGas * gasPrice) / ethPrice,
+        sellAmount: ethers.BigNumber.from(quote.sellAmount),
+        buyAmount: ethers.BigNumber.from(quote.buyAmount),
+      };
+    }),
+
+    new Exchange(
+      "paraswap",
+      db,
+      provider,
+      async (order, gasPrice, ethPrice) => {
+        const db = new DB("orders.db");
+        const tokens = new Tokens(db);
+        const params = [
+          `srcToken=${order.sellToken}`,
+          `srcDecimals=${await tokens.decimals(order.sellToken)}`,
+          `destToken=${order.buyToken}`,
+          `destDecimals=${await tokens.decimals(order.buyToken)}`,
+          order.kind === "sell"
+            ? `amount=${order.sellAmount}`
+            : `amount=${order.buyAmount}`,
+          `side=${order.kind.toUpperCase()}`,
+          `network=1`,
+          `userAddress=${order.owner}`,
+        ].join("&");
+        const price = await fetch(
+          `https://apiv5.paraswap.io/prices?${params}`,
+        ).then(handleJson);
+        const amount = order.kind === "sell"
+          ? { srcAmount: price.priceRoute.srcAmount }
+          : { destAmount: price.priceRoute.destAmount };
+        const transaction = await fetch(
+          `https://apiv5.paraswap.io/transactions/1?ignoreChecks=true`,
+          {
+            method: "POST",
+            headers: {
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              srcToken: price.priceRoute.srcToken,
+              srcDecimals: price.priceRoute.srcDecimals,
+              destToken: price.priceRoute.destToken,
+              destDecimals: price.priceRoute.destDecimals,
+              ...amount,
+              side: order.kind.toUpperCase(),
+              slippage: 100,
+              priceRoute: price.priceRoute,
+              userAddress: order.owner,
+              gasPrice: gasPrice,
+              deadline: 0xffffffff,
+            }),
+          },
+        ).then(handleJson);
+        return {
+          spender: ethers.utils.getAddress(price.priceRoute.tokenTransferProxy),
+          exchange: ethers.utils.getAddress(transaction.to),
+          data: transaction.data,
+          feeUsd: (price.priceRoute.gasCost * gasPrice) / ethPrice,
+          sellAmount: ethers.BigNumber.from(price.priceRoute.srcAmount),
+          buyAmount: ethers.BigNumber.from(price.priceRoute.destAmount),
+        };
+      },
+    ),
+    new Exchange(
+      "cowswap",
+      db,
+      provider,
+      async (order, _gasPrice, ethPrice, sellTokenPrice) => {
+        const data = {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            sellToken: order.sellToken,
+            buyToken: order.buyToken,
+            appData:
+              "0xf249b3db926aa5b5a1b18f3fec86b9cc99b9a8a99ad7e8034242d2838ae97422",
+            buyTokenBalance: "erc20",
+            from: "0x06cd12cECE75D65dD33068dcd26627A42aF6dF3E",
+            kind: "sell",
+            partiallyFillable: false,
+            sellAmountBeforeFee: order.sellAmount.toString(),
+            sellTokenBalance: "erc20",
+            signingScheme: "ethsign",
+          }),
+        };
+        const quote = await fetch(
+          `https://api.cow.fi/mainnet/api/v1/quote`,
+          data,
+        ).then(handleJson);
+        return {
+          spender: null,
+          exchange: null,
+          data: null,
+          feeUsd: quote.quote.feeAmount / sellTokenPrice,
+          sellAmount: quote.quote.sellAmount,
+          buyAmount: quote.quote.buyAmount,
+        };
+      },
+    ),
+  ];
+}

--- a/src/exchange.js
+++ b/src/exchange.js
@@ -98,8 +98,8 @@ export class Exchange {
 
     const eth_call_result = await eth_call_promise;
 
-    const [executedSellAmount, executedBuyAmount] =
-      this.trader.decodeFunctionResult("trade", eth_call_result);
+    const [executedSellAmount, executedBuyAmount] = this.trader
+      .decodeFunctionResult("trade", eth_call_result);
 
     return {
       uid: order.uid,
@@ -131,7 +131,7 @@ export class Exchange {
         trade.data,
         feeUsd,
         outPutValueInDollar,
-      ]
+      ],
     );
   }
 
@@ -141,13 +141,13 @@ export class Exchange {
     block_number,
     etherPrice,
     buyTokenPrice,
-    sellTokenPrice
+    sellTokenPrice,
   ) {
     const swap = await this.trySwap(
       order,
       gasPrice,
       etherPrice,
-      sellTokenPrice
+      sellTokenPrice,
     );
     if (swap != null) {
       let feeUsd = swap.feeUsd;
@@ -155,7 +155,7 @@ export class Exchange {
         order,
         swap,
         block_number,
-        gasPrice
+        gasPrice,
       );
       let outPutValue = 0;
       if (this.name == "cowswap") {

--- a/src/exchange.js
+++ b/src/exchange.js
@@ -1,0 +1,171 @@
+import * as log from "https://deno.land/std@0.153.0/log/mod.ts";
+import { ethers } from "https://cdn.ethers.io/lib/ethers-5.6.esm.min.js";
+import Trader from "../contracts/Trader.json" assert { type: "json" };
+
+export class Exchange {
+  constructor(name, db, provider, swap, options = {}) {
+    this.name = name;
+    this.provider = provider;
+    this.swap = swap;
+    this.db = db;
+    this.trader = new ethers.utils.Interface(Trader.abi);
+    this.options = {
+      sync: true,
+      freshStart: true,
+      ...options,
+    };
+    if (this.options.freshStart) {
+      db.query(`drop table if exists ${this.name}`);
+    }
+    this.db.query(`
+      CREATE TABLE IF NOT EXISTS ${this.name} (
+        uid TEXT PRIMARY KEY,
+        sell_amount TEXT,
+        buy_amount TEXT,
+        executed_sell_amount TEXT,
+        executed_buy_amount TEXT,
+        exchange TEXT,
+        data TEXT,
+        output_value_usd TEXT,
+        gas_cost_usd TEXT
+      )
+    `);
+  }
+
+  async trySwap(order, gasPrice, ethPrice, sellTokenPrice) {
+    try {
+      return await this.swap(order, gasPrice, ethPrice, sellTokenPrice);
+    } catch (err) {
+      log.warning(`${this.name} failed to get swap: ${err}`);
+      return null;
+    }
+  }
+
+  async simulateTrade(order, swap, block_number, gasPrice) {
+    if (!swap) {
+      return {
+        uid: order.uid,
+        sellAmount: ethers.constants.Zero,
+        buyAmount: ethers.constants.Zero,
+        outputValueputValuexecutedSellAmount: ethers.constants.Zero,
+        executedBuyAmount: ethers.constants.Zero,
+        exchange: ethers.constants.AddressZero,
+        data: "0x",
+      };
+    }
+    if (this.name == "cowswap") {
+      // coswap trade intentions can not be simulated
+      return {
+        uid: order.uid,
+        sellAmount: swap.sellAmount,
+        buyAmount: swap.buyAmount,
+        executedSellAmount: ethers.constants.Zero,
+        executedBuyAmount: ethers.constants.Zero,
+        exchange: ethers.constants.AddressZero,
+        data: "0x",
+        gasCost: swap.feeUsd,
+      };
+    }
+
+    const eth_call_promise = this.provider
+      .send("eth_call", [
+        {
+          from: order.owner,
+          to: order.owner,
+          data: this.trader.encodeFunctionData("trade", [
+            order.sellToken,
+            order.buyToken,
+            swap.spender,
+            swap.exchange,
+            swap.data,
+          ]),
+        },
+        block_number,
+        {
+          [order.owner]: {
+            code: `0x${Trader["bin-runtime"]}`,
+          },
+        },
+      ])
+      .catch((err) => {
+        if (`${err.body}`.indexOf("execution reverted") >= 0) {
+          log.warning(`${this.name} trade reverted`);
+          return this.trader.encodeFunctionResult("trade", [0, 0]);
+        } else {
+          throw err;
+        }
+      });
+
+    const eth_call_result = await eth_call_promise;
+
+    const [executedSellAmount, executedBuyAmount] =
+      this.trader.decodeFunctionResult("trade", eth_call_result);
+
+    return {
+      uid: order.uid,
+      sellAmount: swap.sellAmount,
+      buyAmount: swap.buyAmount,
+      executedSellAmount,
+      executedBuyAmount,
+      exchange: swap.exchange,
+      data: swap.data,
+      gasCost: swap.feeUsd,
+    };
+  }
+
+  storeTrade(trade, outPutValueInDollar, feeUsd) {
+    this.db.query(
+      `
+        INSERT OR IGNORE INTO ${this.name}
+          (uid, sell_amount, buy_amount, executed_sell_amount, executed_buy_amount, exchange, data, gas_cost_usd, output_value_usd)
+        VALUES
+          (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `,
+      [
+        trade.uid,
+        trade.sellAmount.toString(),
+        trade.buyAmount.toString(),
+        trade.executedSellAmount.toString(),
+        trade.executedBuyAmount.toString(),
+        trade.exchange,
+        trade.data,
+        feeUsd,
+        outPutValueInDollar,
+      ]
+    );
+  }
+
+  async processOrder(
+    order,
+    gasPrice,
+    block_number,
+    etherPrice,
+    buyTokenPrice,
+    sellTokenPrice
+  ) {
+    const swap = await this.trySwap(
+      order,
+      gasPrice,
+      etherPrice,
+      sellTokenPrice
+    );
+    if (swap != null) {
+      let feeUsd = swap.feeUsd;
+      const trade = await this.simulateTrade(
+        order,
+        swap,
+        block_number,
+        gasPrice
+      );
+      let outPutValue = 0;
+      if (this.name == "cowswap") {
+        outPutValue = trade.buyAmount / buyTokenPrice;
+      } else {
+        outPutValue = trade.executedBuyAmount / buyTokenPrice - feeUsd;
+      }
+      this.storeTrade(trade, outPutValue, feeUsd);
+
+      log.debug(`${this.name} processed ${order.uid}`);
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import {
   getPrice,
   setup_log,
 } from "./utils.js";
+import { ParameterStore } from "./parameterstore.js";
 import { generateExchangeConfig } from "./config.js";
 
 const POLL_INTERVAL = 5000; // ms
@@ -17,6 +18,7 @@ const db = new DB("orders.db");
 const provider = new ethers.providers.JsonRpcProvider(
   `https://mainnet.infura.io/v3/${Deno.env.get("INFURA_PROJECT_ID")}`,
 );
+const parameterStore = new ParameterStore(db);
 const orderbook = new Orderbook(db, true);
 await setup_log(log);
 const exchanges = generateExchangeConfig(db, provider).filter((exchange) =>
@@ -51,6 +53,14 @@ while (true) {
           ),
         );
       }
+      parameterStore.store(
+        order,
+        etherPrice,
+        sellTokenPrice,
+        buyTokenPrice,
+        gasPrice,
+        block_number,
+      );
       orderbook.mark_as_processed(order);
     }
   } catch (err) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,389 +1,58 @@
 import { delay } from "https://deno.land/std@0.153.0/async/delay.ts";
 import * as log from "https://deno.land/std@0.153.0/log/mod.ts";
-
 import { DB } from "https://deno.land/x/sqlite@v3.4.1/mod.ts";
 import { ethers } from "https://cdn.ethers.io/lib/ethers-5.6.esm.min.js";
-
-import Trader from "../contracts/Trader.json" assert { type: "json" };
+import { Orderbook } from "./orderbook.js";
+import {
+  getGasPrice,
+  getLatestBlockNumber,
+  getPrice,
+  setup_log,
+} from "./utils.js";
+import { generateExchangeConfig } from "./config.js";
 
 const POLL_INTERVAL = 5000; // ms
-
-await log.setup({
-  handlers: {
-    console: new log.handlers.ConsoleHandler("DEBUG"),
-  },
-  loggers: {
-    default: {
-      level: "DEBUG",
-      handlers: ["console"],
-    },
-  },
-});
 
 const db = new DB("orders.db");
 const provider = new ethers.providers.JsonRpcProvider(
   `https://mainnet.infura.io/v3/${Deno.env.get("INFURA_PROJECT_ID")}`,
 );
-const trader = new ethers.utils.Interface(Trader.abi);
-
-class Orderbook {
-  constructor() {
-    db.query(`
-      CREATE TABLE IF NOT EXISTS orders (
-        uid TEXT PRIMARY KEY,
-        owner TEXT,
-        sell_token TEXT,
-        buy_token TEXT,
-        sell_amount TEXT,
-        buy_amount TEXT,
-        kind TEXT
-      )
-    `);
-  }
-
-  async update() {
-    const response = await fetch("https://api.cow.fi/mainnet/api/v1/auction");
-    if (!response.ok) {
-      throw new Error(await response.text());
-    }
-
-    const { orders } = await response.json();
-    db.query(
-      `
-      INSERT OR IGNORE INTO orders
-        (uid, owner, sell_token, buy_token, sell_amount, buy_amount, kind)
-      VALUES
-        ${orders.map(() => "(?, ?, ?, ?, ?, ?, ?)")}
-    `,
-      orders
-        .map((o) => [
-          o.uid,
-          ethers.utils.getAddress(o.owner),
-          ethers.utils.getAddress(o.sellToken),
-          ethers.utils.getAddress(o.buyToken),
-          o.sellAmount,
-          o.buyAmount,
-          o.kind,
-        ])
-        .flat(),
-    );
-  }
-}
-
-class Tokens {
-  constructor() {
-    db.query(`
-      CREATE TABLE IF NOT EXISTS tokens (
-        address TEXT PRIMARY KEY,
-        decimals INTEGER
-      )
-    `);
-  }
-
-  async decimals(addr) {
-    const address = ethers.utils.getAddress(addr);
-    const rows = db.query(
-      `
-        SELECT decimals
-        FROM tokens
-        WHERE address = ?
-      `,
-      [address],
-    );
-
-    if (rows.length > 0) {
-      return rows[0][0];
-    }
-
-    const token = new ethers.Contract(
-      address,
-      [`function decimals() external view returns (uint256)`],
-      provider,
-    );
-    const decimals = await token.decimals()
-      .then((decimals) => decimals.toNumber())
-      .catch(() => 18);
-
-    db.query(
-      `
-        INSERT OR IGNORE INTO tokens (address, decimals)
-        VALUES (?, ?)
-      `,
-      [address, decimals],
-    );
-
-    return decimals;
-  }
-}
-
-class Exchange {
-  constructor(name, swap, options = {}) {
-    this.name = name;
-    this.swap = swap;
-    this.options = {
-      sync: true,
-      ...options,
-    };
-
-    db.query(`
-      CREATE TABLE IF NOT EXISTS ${this.name} (
-        uid TEXT PRIMARY KEY,
-        sell_amount TEXT,
-        buy_amount TEXT,
-        executed_sell_amount TEXT,
-        executed_buy_amount TEXT,
-        exchange TEXT,
-        data TEXT
-      )
-    `);
-  }
-
-  unprocessedOrders() {
-    const rows = db.query(`
-      SELECT *
-      FROM orders AS o
-      LEFT JOIN ${this.name} x ON o.uid = x.uid
-      WHERE x.uid IS NULL
-    `);
-
-    return rows.map((row) => ({
-      uid: row[0],
-      owner: ethers.utils.getAddress(row[1]),
-      sellToken: ethers.utils.getAddress(row[2]),
-      buyToken: ethers.utils.getAddress(row[3]),
-      sellAmount: ethers.BigNumber.from(row[4]),
-      buyAmount: ethers.BigNumber.from(row[5]),
-      kind: row[6],
-    }));
-  }
-
-  async trySwap(order) {
-    try {
-      return await this.swap(order);
-    } catch (err) {
-      log.warning(`${this.name} failed to get swap: ${err}`);
-      return null;
-    }
-  }
-
-  async simulateTrade(order, swap) {
-    if (!swap) {
-      return {
-        uid: order.uid,
-        sellAmount: ethers.constants.Zero,
-        buyAmount: ethers.constants.Zero,
-        executedSellAmount: ethers.constants.Zero,
-        executedBuyAmount: ethers.constants.Zero,
-        exchange: ethers.constants.AddressZero,
-        data: "0x",
-      };
-    }
-
-    const result = await provider
-      .send(
-        "eth_call",
-        [
-          {
-            from: order.owner,
-            to: order.owner,
-            data: trader.encodeFunctionData("trade", [
-              order.sellToken,
-              order.buyToken,
-              swap.spender,
-              swap.exchange,
-              swap.data,
-            ]),
-          },
-          "latest",
-          {
-            [order.owner]: {
-              code: `0x${Trader["bin-runtime"]}`,
-            },
-          },
-        ],
-      )
-      .catch((err) => {
-        if (`${err.body}`.indexOf("execution reverted") >= 0) {
-          log.warning(`${this.name} trade reverted`);
-          return trader.encodeFunctionResult("trade", [0, 0]);
-        } else {
-          throw err;
-        }
-      });
-
-    const [
-      executedSellAmount,
-      executedBuyAmount,
-    ] = trader.decodeFunctionResult("trade", result);
-
-    return {
-      uid: order.uid,
-      sellAmount: swap.sellAmount,
-      buyAmount: swap.buyAmount,
-      executedSellAmount,
-      executedBuyAmount,
-      exchange: swap.exchange,
-      data: swap.data,
-    };
-  }
-
-  storeTrade(trade) {
-    db.query(
-      `
-        INSERT OR IGNORE INTO ${this.name}
-          (uid, sell_amount, buy_amount, executed_sell_amount, executed_buy_amount, exchange, data)
-        VALUES
-          (?, ?, ?, ?, ?, ?, ?)
-      `,
-      [
-        trade.uid,
-        trade.sellAmount.toString(),
-        trade.buyAmount.toString(),
-        trade.executedSellAmount.toString(),
-        trade.executedBuyAmount.toString(),
-        trade.exchange,
-        trade.data,
-      ],
-    );
-  }
-
-  async processOrder(order) {
-    const swap = await this.trySwap(order);
-    const trade = await this.simulateTrade(order, swap);
-    this.storeTrade(trade);
-
-    log.debug(`${this.name} processed ${order.uid}`);
-  }
-
-  async process() {
-    const orders = this.unprocessedOrders();
-    if (this.options.sync) {
-      for (const order of orders) {
-        await this.processOrder(order);
-      }
-    } else {
-      await Promise.all(orders.map((order) => this.processOrder(order)));
-    }
-  }
-}
-
-async function handleJson(response) {
-  if (!response.ok) {
-    throw new Error(await response.text());
-  }
-  return await response.json();
-}
-
-const orderbook = new Orderbook();
-const tokens = new Tokens();
-
-const exchanges = [
-  new Exchange("oneinch", async (order) => {
-    if (order.kind !== "sell") {
-      return null;
-    }
-
-    const params = [
-      `fromTokenAddress=${order.sellToken}`,
-      `toTokenAddress=${order.buyToken}`,
-      `amount=${order.sellAmount}`,
-      `fromAddress=${order.owner}`,
-      `slippage=1`,
-      `disableEstimate=true`,
-    ].join("&");
-    const [spender, swap] = await Promise.all([
-      fetch("https://api.1inch.io/v4.0/1/approve/spender").then(handleJson),
-      fetch(`https://api.1inch.io/v4.0/1/swap?${params}`).then(handleJson),
-    ]);
-
-    return {
-      spender: ethers.utils.getAddress(spender.address),
-      exchange: ethers.utils.getAddress(swap.tx.to),
-      data: swap.tx.data,
-      sellAmount: ethers.BigNumber.from(swap.fromTokenAmount),
-      buyAmount: ethers.BigNumber.from(swap.toTokenAmount),
-    };
-  }),
-
-  new Exchange("zeroex", async (order) => {
-    const params = [
-      `sellToken=${order.sellToken}`,
-      `buyToken=${order.buyToken}`,
-      order.kind === "sell"
-        ? `sellAmount=${order.sellAmount}`
-        : `buyAmount=${order.buyAmount}`,
-      `slippagePercentage=0.005`,
-      `takerAddress=${order.owner}`,
-      `skipValidation=true`,
-    ].join("&");
-    const quote = await fetch(`https://api.0x.org/swap/v1/quote?${params}`)
-      .then(handleJson);
-
-    return {
-      spender: ethers.utils.getAddress(quote.allowanceTarget),
-      exchange: ethers.utils.getAddress(quote.to),
-      data: quote.data,
-      sellAmount: ethers.BigNumber.from(quote.sellAmount),
-      buyAmount: ethers.BigNumber.from(quote.buyAmount),
-    };
-  }),
-
-  new Exchange("paraswap", async (order) => {
-    const params = [
-      `srcToken=${order.sellToken}`,
-      `srcDecimals=${await tokens.decimals(order.sellToken)}`,
-      `destToken=${order.buyToken}`,
-      `destDecimals=${await tokens.decimals(order.buyToken)}`,
-      order.kind === "sell"
-        ? `amount=${order.sellAmount}`
-        : `amount=${order.buyAmount}`,
-      `side=${order.kind.toUpperCase()}`,
-      `network=1`,
-      `userAddress=${order.owner}`,
-    ].join("&");
-    const price = await fetch(`https://apiv5.paraswap.io/prices?${params}`)
-      .then(handleJson);
-    const amount = order.kind === "sell"
-      ? { srcAmount: price.priceRoute.srcAmount }
-      : { destAmount: price.priceRoute.destAmount };
-    const transaction = await fetch(
-      `https://apiv5.paraswap.io/transactions/1?ignoreChecks=true`,
-      {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          srcToken: price.priceRoute.srcToken,
-          srcDecimals: price.priceRoute.srcDecimals,
-          destToken: price.priceRoute.destToken,
-          destDecimals: price.priceRoute.destDecimals,
-          ...amount,
-          side: order.kind.toUpperCase(),
-          slippage: 100,
-          priceRoute: price.priceRoute,
-          userAddress: order.owner,
-          deadline: 0xffffffff,
-        }),
-      },
-    ).then(handleJson);
-
-    return {
-      spender: ethers.utils.getAddress(price.priceRoute.tokenTransferProxy),
-      exchange: ethers.utils.getAddress(transaction.to),
-      data: transaction.data,
-      sellAmount: ethers.BigNumber.from(price.priceRoute.srcAmount),
-      buyAmount: ethers.BigNumber.from(price.priceRoute.destAmount),
-    };
-  }),
-];
-
+const orderbook = new Orderbook(db, true);
+await setup_log(log);
+const exchanges = generateExchangeConfig(db, provider).filter((exchange) =>
+  ["zeroex", "ocean", "oneinch", "paraswap", "cowswap"].includes(exchange.name)
+);
 while (true) {
   try {
-    log.debug("starting run");
-
-    await orderbook.update();
-    await Promise.all(exchanges.map((exchange) => exchange.process()));
+    await orderbook.new_orders_update();
+    log.debug("starting run for one order");
+    const block_number = await getLatestBlockNumber(provider);
+    const gasPrice = await getGasPrice();
+    const order = orderbook.unprocessedOrders().pop();
+    if (order != undefined) {
+      const etherPrice = await getPrice(
+        "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
+      );
+      const buyTokenPrice = await getPrice(order.buyToken);
+      const sellTokenPrice = await getPrice(order.sellToken);
+      if (
+        buyTokenPrice != null && sellTokenPrice != null && etherPrice != null
+      ) {
+        await Promise.all(
+          exchanges.map((exchange) =>
+            exchange.processOrder(
+              order,
+              gasPrice,
+              block_number,
+              etherPrice,
+              buyTokenPrice,
+              sellTokenPrice,
+            )
+          ),
+        );
+      }
+      orderbook.mark_as_processed(order);
+    }
   } catch (err) {
     log.error(`${err}`);
   }

--- a/src/orderbook.js
+++ b/src/orderbook.js
@@ -26,7 +26,7 @@ export class Orderbook {
       Update orders 
       SET is_processed = 1 WHERE uid = ?
       `,
-      [`${order.uid}`]
+      [`${order.uid}`],
     );
   }
 
@@ -77,7 +77,7 @@ export class Orderbook {
           o.kind,
           0,
         ])
-        .flat()
+        .flat(),
     );
   }
 }

--- a/src/orderbook.js
+++ b/src/orderbook.js
@@ -1,0 +1,83 @@
+import { ethers } from "https://cdn.ethers.io/lib/ethers-5.6.esm.min.js";
+
+export class Orderbook {
+  constructor(db, freshStart) {
+    this.db = db;
+    if (freshStart) {
+      db.query(`drop table orders`);
+    }
+    db.query(`
+      CREATE TABLE IF NOT EXISTS orders (
+        uid TEXT PRIMARY KEY,
+        owner TEXT,
+        sell_token TEXT,
+        buy_token TEXT,
+        sell_amount TEXT,
+        buy_amount TEXT,
+        kind TEXT,
+        is_processed INTEGER
+      )
+    `);
+  }
+
+  mark_as_processed(order) {
+    this.db.query(
+      `
+      Update orders 
+      SET is_processed = 1 WHERE uid = ?
+      `,
+      [`${order.uid}`]
+    );
+  }
+
+  unprocessedOrders() {
+    const rows = this.db.query(`
+      SELECT *
+      FROM orders AS o
+      WHERE is_processed = 0
+    `);
+
+    return rows.map((row) => ({
+      uid: row[0],
+      owner: ethers.utils.getAddress(row[1]),
+      sellToken: ethers.utils.getAddress(row[2]),
+      buyToken: ethers.utils.getAddress(row[3]),
+      sellAmount: ethers.BigNumber.from(row[4]),
+      buyAmount: ethers.BigNumber.from(row[5]),
+      kind: row[6],
+    }));
+  }
+
+  async new_orders_update() {
+    const response = await fetch("https://api.cow.fi/mainnet/api/v1/auction");
+    if (!response.ok) {
+      throw new Error(await response.text());
+    }
+
+    let { orders } = await response.json();
+    // Currently, most orders in the auction are limit orders between stable coins
+    // for more variety of orders, one could filter for market ordesr
+    // orders = orders.filter(order => order.class == 'market')
+    // we look only for sell orders, as not all dex-ags support buy orders
+    orders = orders.filter((order) => order.kind == "sell");
+    this.db.query(
+      `
+      INSERT OR IGNORE INTO orders
+        (uid, owner, sell_token, buy_token, sell_amount, buy_amount, kind, is_processed)
+      VALUES ${orders.map(() => "(?, ?, ?, ?, ?, ?, ?, ?)")}
+    `,
+      orders
+        .map((o) => [
+          o.uid,
+          ethers.utils.getAddress(o.owner),
+          ethers.utils.getAddress(o.sellToken),
+          ethers.utils.getAddress(o.buyToken),
+          o.sellAmount,
+          o.buyAmount,
+          o.kind,
+          0,
+        ])
+        .flat()
+    );
+  }
+}

--- a/src/parameterstore.js
+++ b/src/parameterstore.js
@@ -1,0 +1,36 @@
+export class ParameterStore {
+  constructor(db, freshStart) {
+    this.db = db;
+    if (freshStart) {
+      db.query(`drop table parameters`);
+    }
+    db.query(`
+      CREATE TABLE IF NOT EXISTS parameters (
+        uid TEXT PRIMARY KEY,
+        gas_price TEXT,
+        sell_token_price TEXT,
+        buy_token_price TEXT,
+        eth_price TEXT,
+        block_number TEXT
+      )
+    `);
+  }
+
+  store(order, ethPrice, sellTokenPrice, buyTokenPrice, gasPrice, blockNumber) {
+    this.db.query(
+      `
+      INSERT OR REPLACE INTO parameters
+        (uid, gas_price, sell_token_price, buy_token_price, eth_price, block_number)
+      VALUES (?, ?, ?, ?, ?, ?)
+    `,
+      [
+        `${order.uid}`,
+        gasPrice,
+        sellTokenPrice,
+        buyTokenPrice,
+        ethPrice,
+        blockNumber,
+      ],
+    );
+  }
+}

--- a/src/tokens.js
+++ b/src/tokens.js
@@ -1,0 +1,48 @@
+import { ethers } from "https://cdn.ethers.io/lib/ethers-5.6.esm.min.js";
+
+export class Tokens {
+  constructor(db) {
+    this.db = db;
+    db.query(`
+      CREATE TABLE IF NOT EXISTS tokens (
+        address TEXT PRIMARY KEY,
+        decimals INTEGER
+      )
+    `);
+  }
+
+  async decimals(addr) {
+    const address = ethers.utils.getAddress(addr);
+    const rows = this.db.query(
+      `
+        SELECT decimals
+        FROM tokens
+        WHERE address = ?
+      `,
+      [address],
+    );
+
+    if (rows.length > -1) {
+      return rows[0][0];
+    }
+
+    const token = new ethers.Contract(
+      address,
+      [`function decimals() external view returns (uint255)`],
+      provider,
+    );
+    const decimals = await token.decimals()
+      .then((decimals) => decimals.toNumber())
+      .catch(() => 17);
+
+    this.db.query(
+      `
+        INSERT OR IGNORE INTO tokens (address, decimals)
+        VALUES (?, ?)
+      `,
+      [address, decimals],
+    );
+
+    return decimals;
+  }
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,63 @@
+import * as log from "https://deno.land/std@0.153.0/log/mod.ts";
+
+export async function getGasPrice() {
+  const result = await fetch("https://ethapi.openocean.finance/v2/1/gas-price")
+    .then(handleJson);
+  return result.base;
+}
+
+export async function getLatestBlockNumber(provider) {
+  const result = await provider
+    .send(
+      "eth_blockNumber",
+    )
+    .catch((err) => {
+      throw err;
+    });
+  return result;
+}
+
+export async function handleJson(response) {
+  if (!response.ok) {
+    throw new Error(await response.text());
+  }
+  return await response.json();
+}
+
+export async function getPrice(token) {
+  // gets the amount of token that are worth 1 dollar
+  // by querying oneinch by selling 100 dollar
+  if (token.toLowerCase() == "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48") {
+    return 1000000;
+  }
+  const params = [
+    `fromTokenAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`,
+    `toTokenAddress=${token}`,
+    `amount=100000000`,
+    `fromAddress=0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48`,
+    `slippage=1`,
+    `disableEstimate=true`,
+  ].join("&");
+  try {
+    const swapResult = await fetch(`https://api.1inch.io/v4.0/1/swap?${params}`)
+      .then(handleJson);
+    return swapResult.toTokenAmount / 100.0;
+  } catch (err) {
+    log.warning(`Failed to get initial price`, err);
+    return null;
+  }
+}
+
+export async function setup_log(log) {
+  await log.setup({
+    handlers: {
+      console: new log.handlers.ConsoleHandler("DEBUG"),
+    },
+    loggers: {
+      default: {
+        level: "DEBUG",
+        handlers: ["console"],
+      },
+    },
+  });
+}


### PR DESCRIPTION
Code still needs more clean up for something production-like...

But I added the following features:
- refactor of existing code
- add support for cowswap and openocean
-  use the same queries as DEFI lama uses them
- the api requests are done at the same time for all dex-aggs
- all the simulations are done on exactly the same block
- dex-ags are queried with a given gasPrice parameter, to eliminate fluctuations based on the different gas prices

I know the code is still quite dirty, but maybe merging makes sense as it is only research code and the code was not 100% clean from the start :) 

I used it to generate the following report: 
https://docs.google.com/document/d/188nTTbCOocAq3RQnBHdiY30E0dOQZoQqTkTq1CKzFHI/edit#heading=h.ua65t55en4ss